### PR TITLE
Fix missing dotenv config and signin crash

### DIFF
--- a/src/handlers/user.ts
+++ b/src/handlers/user.ts
@@ -18,6 +18,12 @@ export const signIn = async (req, res) => {
       username: req.body.username,
     },
   });
+  if (!user) {
+    res.status(401);
+    res.json({ message: "Invalid username or password" });
+    return;
+  }
+
   const isValid = await comparePassword(req.body.password, user.password);
   if (!isValid) {
     res.status(401);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import * as dotenv from "dotenv";
 import app from "./server";
 
+dotenv.config();
+
 app.listen(3001, () => {
   console.log("listening on port 3001");
 });


### PR DESCRIPTION
## Summary
- load environment variables on startup
- handle missing users in the signIn handler

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d9d81daa4832288d8b8a54af32dd9