### PR TITLE
Rename hashedPassword to hashPassword

### DIFF
--- a/src/handlers/user.ts
+++ b/src/handlers/user.ts
@@ -1,11 +1,11 @@
 import prisma from "../db";
-import { comparePassword, createJWT, hashedPassword } from "../modules/auth";
+import { comparePassword, createJWT, hashPassword } from "../modules/auth";
 
 export const createNewUser = async (req, res) => {
   const user = await prisma.user.create({
     data: {
       username: req.body.username,
-      password: await hashedPassword(req.body.password),
+    password: await hashPassword(req.body.password),
     },
   });
   const token = createJWT(user);

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -5,7 +5,7 @@ export const comparePassword = (password, hash) => {
   return bcrypt.compare(password, hash);
 };
 
-export const hashedPassword = (password) => {
+export const hashPassword = (password) => {
   return bcrypt.hash(password, 10);
 };
 export const createJWT = (user) => {


### PR DESCRIPTION
## Summary
- rename `hashedPassword` function to `hashPassword`
- update imports and usage in user handler

## Testing
- `npm install`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d9ee49f1483228526108d8a5ecc4f